### PR TITLE
Opt Out Message on Bot Join

### DIFF
--- a/quackfactory/bot.py
+++ b/quackfactory/bot.py
@@ -16,6 +16,7 @@ class QuackFactory(commands.Bot):
     
     # This will have to change to cog_commands instead of a hard coded string
     self.load_extension('cogs.reactions')
+    self.load_extension('cogs.on_join')
 
   async def on_ready(self):
     log.info(f'Quack logged in: {self.user} (ID: {self.user.id})')

--- a/quackfactory/cogs/on_join.py
+++ b/quackfactory/cogs/on_join.py
@@ -1,0 +1,25 @@
+from discord.ext import commands
+import discord
+import logging
+
+log = logging.getLogger(__name__)
+
+JOIN_MESSAGE_CHANNEL_ID = 784643833488998411
+
+class OnJoin(commands.Cog):
+  def __init__(self, bot):
+    self.bot = bot
+  
+  @commands.Cog.listener()
+  async def on_guild_join(self, guild):
+    log.debug(f'CHANNEL INFO HERE {guild.channels}')
+    join_channel = guild.get_channel(JOIN_MESSAGE_CHANNEL_ID)
+
+    embedCard = discord.Embed(title="Rubber Duck Debugging", description="Rubber Duck Debugging is a problem solving exercise whereby the individual explains the issue at hand, in simple terms, line by line -- to a rubber duck.", color=0xffff00)
+    embedCard.add_field(name="Opt-Out", value="If you don't want to take part, react to this message with a 👎", inline=False)
+
+    join_message = await join_channel.send(embed=embedCard)
+    await join_message.add_reaction("👎")
+
+def setup(bot):
+  bot.add_cog(OnJoin(bot))


### PR DESCRIPTION
When the bot joins the server, it creates a message that prompts users that want to opt out to react with a thumbs down emoji.
![image](https://user-images.githubusercontent.com/44061647/101234916-88e81100-3691-11eb-8042-15d72bdad50d.png)

The value of `JOIN_MESSAGE_CHANNEL_ID` can be modified for testing. Currently hardcoded the value.

